### PR TITLE
irc: Add QUIT handling

### DIFF
--- a/src/ircd/proto.rs
+++ b/src/ircd/proto.rs
@@ -222,6 +222,10 @@ pub async fn ircd_sync_read(
                     }
                 }
             }
+            Command::QUIT(msg) => {
+                info!("QUIT {}", msg.unwrap_or_default());
+                break;
+            }
             Command::ChannelMODE(chan, modes) if modes.is_empty() => {
                 if let Err(e) = matrirc
                     .irc()


### PR DESCRIPTION
This closes the connection if the client sends quit

In particular it allows irssi to exit quickly on /quit as it waits for servers to close connections

(added in the middle to not causes conflicts with other in flight PRs, might want to reorder these alphabetically or something later)

-----
this pr mostly to test workflow setting works