### PR TITLE
Do not overwrite saved media files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,6 +1948,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-util",
 ]
@@ -3349,9 +3350,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
  "fastrand",
  "getrandom 0.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,6 @@ rand_core = { version = "0.9", features = ["os_rng"] }
 regex = "1.8"
 serde = "1.0"
 serde_json = "1.0"
+tempfile = "3.19.1"
 tokio = { version = "1.0.0", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"] }


### PR DESCRIPTION
If a file with the requested filename already exists in --media-dir, divert the write to a new, uniquely named file (based on the original filename) via the tempfile crate.

It's all a bit complicated because there appears to exist no readily available async variation of `mkstemp`-like functionality, so there is a need to wrap it in a `spawn_blocking`, but later reopen it outside for then obtaining an async `tokio::fs::file`.
Comments on making that more concise are more than welcome :)